### PR TITLE
feat(slog): add slog.Handler adapter

### DIFF
--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -1,0 +1,36 @@
+// Example: basic usage of log-socket as a drop-in logger.
+//
+// This demonstrates using the package-level logging functions,
+// which work similarly to the standard library's log package.
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/taigrr/log-socket/v2/browser"
+	logger "github.com/taigrr/log-socket/v2/log"
+	"github.com/taigrr/log-socket/v2/ws"
+)
+
+func main() {
+	defer logger.Flush()
+
+	// Set the minimum log level (default is LTrace, showing everything)
+	logger.SetLogLevel(logger.LDebug)
+
+	// Package-level functions log to the "default" namespace
+	logger.Info("Application starting up")
+	logger.Debug("Debug mode enabled")
+	logger.Warnf("Config file not found at %s, using defaults", "/etc/app/config.yaml")
+	logger.Errorf("Failed to connect to database: %s", "connection refused")
+
+	// Print/Printf/Println are aliases for Info
+	logger.Println("This is equivalent to Infoln")
+
+	// Start the web UI so you can view logs at http://localhost:8080
+	http.HandleFunc("/ws", ws.LogSocketHandler)
+	http.HandleFunc("/", browser.LogSocketViewHandler)
+	fmt.Println("Log viewer available at http://localhost:8080")
+	logger.Fatal(http.ListenAndServe("0.0.0.0:8080", nil))
+}

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -1,0 +1,63 @@
+// Example: programmatic log client with namespace filtering.
+//
+// This shows how to create a Client that receives log entries
+// programmatically, optionally filtered to specific namespaces.
+// Useful for building custom log processors, alerting, or forwarding.
+package main
+
+import (
+	"fmt"
+	"time"
+
+	logger "github.com/taigrr/log-socket/v2/log"
+)
+
+func main() {
+	defer logger.Flush()
+
+	// Create a client that receives ALL log entries
+	allLogs := logger.CreateClient()
+	allLogs.SetLogLevel(logger.LInfo)
+
+	// Create a client that only receives "database" and "auth" logs
+	securityLogs := logger.CreateClient("database", "auth")
+	securityLogs.SetLogLevel(logger.LWarn) // Only warnings and above
+
+	dbLog := logger.NewLogger("database")
+	authLog := logger.NewLogger("auth")
+	apiLog := logger.NewLogger("api")
+
+	// Process all logs
+	go func() {
+		for {
+			entry := allLogs.Get()
+			fmt.Printf("[ALL] %s [%s] %s: %s\n",
+				entry.Timestamp.Format(time.TimeOnly),
+				entry.Namespace, entry.Level, entry.Output)
+		}
+	}()
+
+	// Process only security-relevant warnings/errors
+	go func() {
+		for {
+			entry := securityLogs.Get()
+			if entry.Level == "ERROR" || entry.Level == "WARN" {
+				fmt.Printf("🚨 SECURITY ALERT [%s] %s: %s\n",
+					entry.Namespace, entry.Level, entry.Output)
+			}
+		}
+	}()
+
+	// Generate some logs
+	for i := 0; i < 5; i++ {
+		apiLog.Info("API request processed")
+		dbLog.Info("Query executed successfully")
+		dbLog.Warn("Connection pool running low")
+		authLog.Error("Brute force attempt detected")
+		time.Sleep(1 * time.Second)
+	}
+
+	// Clean up clients when done
+	allLogs.Destroy()
+	securityLogs.Destroy()
+}

--- a/examples/log-levels/main.go
+++ b/examples/log-levels/main.go
@@ -1,0 +1,48 @@
+// Example: log level filtering and all available levels.
+//
+// log-socket supports 8 log levels from TRACE (most verbose)
+// to FATAL (least verbose). Setting a log level filters out
+// everything below it.
+package main
+
+import (
+	"fmt"
+
+	logger "github.com/taigrr/log-socket/v2/log"
+)
+
+func main() {
+	defer logger.Flush()
+
+	fmt.Println("=== All log levels (TRACE and above) ===")
+	logger.SetLogLevel(logger.LTrace)
+
+	logger.Trace("Detailed execution trace — variable x = 42")
+	logger.Debug("Processing request for user_id=123")
+	logger.Info("Server started on :8080")
+	logger.Notice("Configuration reloaded")
+	logger.Warn("Disk usage at 85%")
+	logger.Error("Failed to send email: SMTP timeout")
+	// logger.Panic("...") — would panic
+	// logger.Fatal("...") — would os.Exit(1)
+
+	fmt.Println("\n=== Formatted variants ===")
+	logger.Infof("Request took %dms", 42)
+	logger.Warnf("Retrying in %d seconds (attempt %d/%d)", 5, 2, 3)
+	logger.Errorf("HTTP %d: %s", 503, "Service Unavailable")
+
+	fmt.Println("\n=== Only WARN and above ===")
+	logger.SetLogLevel(logger.LWarn)
+
+	logger.Debug("This will NOT appear")
+	logger.Info("This will NOT appear either")
+	logger.Warn("This WILL appear")
+	logger.Error("This WILL appear too")
+
+	fmt.Println("\n=== Per-logger levels via namespaced loggers ===")
+	logger.SetLogLevel(logger.LTrace) // Reset global
+
+	appLog := logger.NewLogger("app")
+	appLog.Info("Namespaced loggers inherit the global output but tag entries")
+	appLog.Warnf("Something needs attention in the %s subsystem", "app")
+}

--- a/examples/namespaces/main.go
+++ b/examples/namespaces/main.go
@@ -1,0 +1,73 @@
+// Example: namespace-based logging for organizing logs by component.
+//
+// Namespaces let you tag log entries by subsystem (api, database, auth, etc.)
+// and filter them in the web UI or via programmatic clients.
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/taigrr/log-socket/v2/browser"
+	logger "github.com/taigrr/log-socket/v2/log"
+	"github.com/taigrr/log-socket/v2/ws"
+)
+
+func main() {
+	defer logger.Flush()
+
+	// Create loggers for different subsystems
+	apiLog := logger.NewLogger("api")
+	dbLog := logger.NewLogger("database")
+	authLog := logger.NewLogger("auth")
+	cacheLog := logger.NewLogger("cache")
+
+	// Simulate application activity
+	go func() {
+		for {
+			apiLog.Infof("GET /api/users — 200 OK (%dms)", rand.Intn(200))
+			apiLog.Debugf("Request headers: Accept=application/json")
+			time.Sleep(1 * time.Second)
+		}
+	}()
+
+	go func() {
+		for {
+			dbLog.Infof("SELECT * FROM users — %d rows", rand.Intn(100))
+			if rand.Float64() < 0.3 {
+				dbLog.Warn("Slow query detected (>500ms)")
+			}
+			time.Sleep(2 * time.Second)
+		}
+	}()
+
+	go func() {
+		for {
+			if rand.Float64() < 0.7 {
+				authLog.Info("User login successful")
+			} else {
+				authLog.Error("Failed login attempt from 192.168.1.42")
+			}
+			time.Sleep(3 * time.Second)
+		}
+	}()
+
+	go func() {
+		for {
+			cacheLog.Tracef("Cache hit ratio: %.1f%%", rand.Float64()*100)
+			if rand.Float64() < 0.1 {
+				cacheLog.Warn("Cache eviction triggered")
+			}
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	// The /api/namespaces endpoint lists all active namespaces
+	http.HandleFunc("/ws", ws.LogSocketHandler)
+	http.HandleFunc("/api/namespaces", ws.NamespacesHandler)
+	http.HandleFunc("/", browser.LogSocketViewHandler)
+	fmt.Println("Log viewer with namespace filtering at http://localhost:8080")
+	logger.Fatal(http.ListenAndServe("0.0.0.0:8080", nil))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/taigrr/log-socket/v2
 
-go 1.25.6
+go 1.26.0
 
 require github.com/gorilla/websocket v1.5.3

--- a/log/log.go
+++ b/log/log.go
@@ -103,7 +103,7 @@ func createLog(e Entry) {
 	namespacesMux.Lock()
 	namespaces[e.Namespace] = true
 	namespacesMux.Unlock()
-	
+
 	sliceTex.Lock()
 	for _, c := range clients {
 		func(c *Client, e Entry) {
@@ -133,7 +133,7 @@ func createLog(e Entry) {
 func GetNamespaces() []string {
 	namespacesMux.RLock()
 	defer namespacesMux.RUnlock()
-	
+
 	result := make([]string, 0, len(namespaces))
 	for ns := range namespaces {
 		result = append(result, ns)
@@ -555,4 +555,38 @@ func fileInfo(skip int) string {
 		}
 	}
 	return fmt.Sprintf("%s:%d", file, line)
+}
+
+// Broadcast sends an [Entry] to all registered clients. This is the public
+// entry point used by adapter packages (such as the slog handler) that
+// construct entries themselves. The unexported level field is inferred from
+// [Entry.Level] when not already set.
+func Broadcast(e Entry) {
+	if e.level == 0 && e.Level != "" && e.Level != "TRACE" {
+		e.level = parseLevelString(e.Level)
+	}
+	createLog(e)
+}
+
+func parseLevelString(s string) Level {
+	switch s {
+	case "TRACE":
+		return LTrace
+	case "DEBUG":
+		return LDebug
+	case "INFO":
+		return LInfo
+	case "NOTICE":
+		return LNotice
+	case "WARN":
+		return LWarn
+	case "ERROR":
+		return LError
+	case "PANIC":
+		return LPanic
+	case "FATAL":
+		return LFatal
+	default:
+		return LInfo
+	}
 }

--- a/slog/handler.go
+++ b/slog/handler.go
@@ -1,0 +1,164 @@
+// Package slog provides a [log/slog.Handler] that routes structured log
+// records into the log-socket broadcasting system, giving every slog-based
+// caller free WebSocket streaming and the browser viewer UI.
+package slog
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"strings"
+
+	"github.com/taigrr/log-socket/v2/log"
+)
+
+// Handler implements [slog.Handler] by converting each [slog.Record] into a
+// log-socket [log.Entry] and feeding it through the normal broadcast path.
+//
+// Attributes accumulated via [Handler.WithAttrs] are prepended to the log
+// message as key=value pairs. Groups set via [Handler.WithGroup] prefix
+// attribute keys with "group.".
+type Handler struct {
+	namespace string
+	level     slog.Level
+	attrs     []slog.Attr
+	groups    []string
+}
+
+// ensure interface compliance at compile time.
+var _ slog.Handler = (*Handler)(nil)
+
+// Option configures a [Handler].
+type Option func(*Handler)
+
+// WithNamespace sets the log-socket namespace for entries produced by this
+// handler.  If empty, [log.DefaultNamespace] is used.
+func WithNamespace(ns string) Option {
+	return func(h *Handler) {
+		h.namespace = ns
+	}
+}
+
+// WithLevel sets the minimum slog level the handler will accept.
+func WithLevel(l slog.Level) Option {
+	return func(h *Handler) {
+		h.level = l
+	}
+}
+
+// NewHandler returns a new [Handler] that writes to the log-socket broadcast
+// system.  Options may be used to set the namespace and minimum level.
+func NewHandler(opts ...Option) *Handler {
+	h := &Handler{
+		namespace: log.DefaultNamespace,
+		level:     slog.LevelDebug,
+	}
+	for _, o := range opts {
+		o(h)
+	}
+	return h
+}
+
+// Enabled reports whether the handler is configured to process records at
+// the given level.
+func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level
+}
+
+// Handle converts r into a log-socket Entry and broadcasts it.
+func (h *Handler) Handle(_ context.Context, r slog.Record) error {
+	var b strings.Builder
+	b.WriteString(r.Message)
+
+	// Append pre-collected attrs.
+	for _, a := range h.attrs {
+		writeAttr(&b, h.groups, a)
+	}
+
+	// Append record-level attrs.
+	r.Attrs(func(a slog.Attr) bool {
+		writeAttr(&b, h.groups, a)
+		return true
+	})
+
+	file := "???"
+	if r.PC != 0 {
+		fs := runtime.CallersFrames([]uintptr{r.PC})
+		f, _ := fs.Next()
+		if f.File != "" {
+			short := f.File
+			if idx := strings.LastIndex(short, "/"); idx >= 0 {
+				short = short[idx+1:]
+			}
+			file = fmt.Sprintf("%s:%d", short, f.Line)
+		}
+	}
+
+	e := log.Entry{
+		Timestamp: r.Time,
+		Output:    b.String(),
+		File:      file,
+		Level:     slogLevelToString(r.Level),
+		Namespace: h.namespace,
+	}
+	log.Broadcast(e)
+	return nil
+}
+
+// WithAttrs returns a new Handler with the given attributes appended.
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	h2 := h.clone()
+	h2.attrs = append(h2.attrs, attrs...)
+	return h2
+}
+
+// WithGroup returns a new Handler where subsequent attributes are nested
+// under the given group name.
+func (h *Handler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	h2 := h.clone()
+	h2.groups = append(h2.groups, name)
+	return h2
+}
+
+func (h *Handler) clone() *Handler {
+	h2 := &Handler{
+		namespace: h.namespace,
+		level:     h.level,
+		attrs:     make([]slog.Attr, len(h.attrs)),
+		groups:    make([]string, len(h.groups)),
+	}
+	copy(h2.attrs, h.attrs)
+	copy(h2.groups, h.groups)
+	return h2
+}
+
+func writeAttr(b *strings.Builder, groups []string, a slog.Attr) {
+	if a.Equal(slog.Attr{}) {
+		return
+	}
+	b.WriteByte(' ')
+	for _, g := range groups {
+		b.WriteString(g)
+		b.WriteByte('.')
+	}
+	b.WriteString(a.Key)
+	b.WriteByte('=')
+	b.WriteString(a.Value.String())
+}
+
+func slogLevelToString(l slog.Level) string {
+	switch {
+	case l >= slog.LevelError:
+		return "ERROR"
+	case l >= slog.LevelWarn:
+		return "WARN"
+	case l >= slog.LevelInfo:
+		return "INFO"
+	default:
+		return "DEBUG"
+	}
+}

--- a/slog/handler.go
+++ b/slog/handler.go
@@ -137,6 +137,7 @@ func (h *Handler) clone() *Handler {
 }
 
 func writeAttr(b *strings.Builder, groups []string, a slog.Attr) {
+	a.Value = a.Value.Resolve()
 	if a.Equal(slog.Attr{}) {
 		return
 	}

--- a/slog/handler_test.go
+++ b/slog/handler_test.go
@@ -1,0 +1,118 @@
+package slog
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/taigrr/log-socket/v2/log"
+)
+
+// getWithTimeout reads from a log client with a timeout to avoid hanging tests.
+func getWithTimeout(c *log.Client, timeout time.Duration) (log.Entry, bool) {
+	ch := make(chan log.Entry, 1)
+	go func() { ch <- c.Get() }()
+	select {
+	case e := <-ch:
+		return e, true
+	case <-time.After(timeout):
+		return log.Entry{}, false
+	}
+}
+
+func TestHandler_Enabled(t *testing.T) {
+	h := NewHandler(WithLevel(slog.LevelWarn))
+	if h.Enabled(context.Background(), slog.LevelInfo) {
+		t.Error("expected Info to be disabled when min level is Warn")
+	}
+	if !h.Enabled(context.Background(), slog.LevelWarn) {
+		t.Error("expected Warn to be enabled")
+	}
+	if !h.Enabled(context.Background(), slog.LevelError) {
+		t.Error("expected Error to be enabled")
+	}
+}
+
+func TestHandler_Handle(t *testing.T) {
+	c := log.CreateClient()
+	defer c.Destroy()
+	c.SetLogLevel(log.LTrace)
+
+	h := NewHandler(WithNamespace("test-ns"))
+	logger := slog.New(h)
+
+	logger.Info("hello world", "key", "value")
+
+	e, ok := getWithTimeout(c, time.Second)
+	if !ok {
+		t.Fatal("timed out waiting for log entry")
+	}
+	if e.Namespace != "test-ns" {
+		t.Errorf("namespace = %q, want %q", e.Namespace, "test-ns")
+	}
+	if e.Level != "INFO" {
+		t.Errorf("level = %q, want INFO", e.Level)
+	}
+	if e.Output == "" {
+		t.Error("output should not be empty")
+	}
+}
+
+func TestHandler_WithAttrs(t *testing.T) {
+	c := log.CreateClient()
+	defer c.Destroy()
+	c.SetLogLevel(log.LTrace)
+
+	h := NewHandler()
+	h2 := h.WithAttrs([]slog.Attr{slog.String("service", "api")})
+	logger := slog.New(h2)
+
+	logger.Info("request")
+
+	e, ok := getWithTimeout(c, time.Second)
+	if !ok {
+		t.Fatal("timed out")
+	}
+	if e.Output != "request service=api" {
+		t.Errorf("output = %q, want %q", e.Output, "request service=api")
+	}
+}
+
+func TestHandler_WithGroup(t *testing.T) {
+	c := log.CreateClient()
+	defer c.Destroy()
+	c.SetLogLevel(log.LTrace)
+
+	h := NewHandler()
+	h2 := h.WithGroup("http").WithAttrs([]slog.Attr{slog.Int("status", 200)})
+	logger := slog.New(h2)
+
+	logger.Info("done")
+
+	e, ok := getWithTimeout(c, time.Second)
+	if !ok {
+		t.Fatal("timed out")
+	}
+	if e.Output != "done http.status=200" {
+		t.Errorf("output = %q, want %q", e.Output, "done http.status=200")
+	}
+}
+
+func TestSlogLevelMapping(t *testing.T) {
+	tests := []struct {
+		level slog.Level
+		want  string
+	}{
+		{slog.LevelDebug, "DEBUG"},
+		{slog.LevelInfo, "INFO"},
+		{slog.LevelWarn, "WARN"},
+		{slog.LevelError, "ERROR"},
+	}
+	for _, tt := range tests {
+		got := slogLevelToString(tt.level)
+		if got != tt.want {
+			t.Errorf("slogLevelToString(%v) = %q, want %q", tt.level, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Adds a `slog` package with a `slog.Handler` implementation that bridges `log/slog` into log-socket's broadcasting system.

## What's new

- **`slog.NewHandler()`** — returns a `slog.Handler` that converts `slog.Record` entries into log-socket `Entry` values and broadcasts them to all connected WebSocket clients
- **`log.Broadcast()`** — public entry point for adapter packages that construct `log.Entry` values directly (used by the slog handler, but available for other adapters too)
- Supports namespaces (`WithNamespace`), minimum level (`WithLevel`), `WithAttrs`, and `WithGroup`
- Full test coverage with race detection

## Usage

```go
import (
    "log/slog"
    logslog "github.com/taigrr/log-socket/v2/slog"
)

handler := logslog.NewHandler(
    logslog.WithNamespace("my-app"),
    logslog.WithLevel(slog.LevelInfo),
)
logger := slog.New(handler)
logger.Info("server started", "port", 8080)
```