### PR TITLE
fix(log): sort namespace registry output

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -139,6 +140,7 @@ func GetNamespaces() []string {
 	for ns := range namespaces {
 		result = append(result, ns)
 	}
+	sort.Strings(result)
 	return result
 }
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -419,6 +419,35 @@ func TestGetNamespaces(t *testing.T) {
 	}
 }
 
+func TestGetNamespacesSorted(t *testing.T) {
+	NewLogger("sort-ns-charlie").Info("register charlie")
+	NewLogger("sort-ns-alpha").Info("register alpha")
+	NewLogger("sort-ns-bravo").Info("register bravo")
+
+	nss := GetNamespaces()
+	indexes := make(map[string]int, len(nss))
+	for index, ns := range nss {
+		indexes[ns] = index
+	}
+
+	alphaIndex, ok := indexes["sort-ns-alpha"]
+	if !ok {
+		t.Fatalf("missing namespace %q in %v", "sort-ns-alpha", nss)
+	}
+	bravoIndex, ok := indexes["sort-ns-bravo"]
+	if !ok {
+		t.Fatalf("missing namespace %q in %v", "sort-ns-bravo", nss)
+	}
+	charlieIndex, ok := indexes["sort-ns-charlie"]
+	if !ok {
+		t.Fatalf("missing namespace %q in %v", "sort-ns-charlie", nss)
+	}
+
+	if !(alphaIndex < bravoIndex && bravoIndex < charlieIndex) {
+		t.Fatalf("expected sorted namespace order, got %v", nss)
+	}
+}
+
 // TestLoggerDebugln verifies the Debugln method on Logger.
 func TestLoggerDebugln(t *testing.T) {
 	c := CreateClient("debugln-test")


### PR DESCRIPTION
## Summary
- sort `GetNamespaces()` output before returning it
- add a regression test that verifies namespace order is deterministic

## Testing
- go test ./...
- staticcheck ./...