### PR TITLE
fix(browser): honor forwarded websocket scheme

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -11,14 +11,25 @@ import (
 var webpage string
 
 func LogSocketViewHandler(w http.ResponseWriter, r *http.Request) {
-	wsResource := r.Host + r.URL.Path
-	if r.TLS != nil {
-		wsResource = "wss://" + wsResource
-	} else {
-		wsResource = "ws://" + wsResource
-	}
+	wsResource := websocketScheme(r) + r.Host + r.URL.Path
 	wsResource = strings.TrimSuffix(wsResource, "/") + "/ws"
 	homeTemplate.Execute(w, wsResource)
+}
+
+func websocketScheme(r *http.Request) string {
+	if forwardedProto := r.Header.Get("X-Forwarded-Proto"); forwardedProto != "" {
+		protocol := strings.ToLower(strings.TrimSpace(strings.Split(forwardedProto, ",")[0]))
+		if protocol == "https" {
+			return "wss://"
+		}
+		if protocol == "http" {
+			return "ws://"
+		}
+	}
+	if r.TLS != nil {
+		return "wss://"
+	}
+	return "ws://"
 }
 
 var homeTemplate = template.Must(template.New("").Parse(webpage))

--- a/browser/browser_test.go
+++ b/browser/browser_test.go
@@ -1,6 +1,7 @@
 package browser
 
 import (
+	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -49,5 +50,30 @@ func TestLogSocketViewHandler_TrailingSlashTrimmed(t *testing.T) {
 	}
 	if !strings.Contains(body, `ws:\/\/example.com\/ws`) {
 		t.Error("expected escaped ws://example.com/ws in body")
+	}
+}
+
+func TestLogSocketViewHandler_ForwardedHTTPSUsesWSS(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/logs/", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	LogSocketViewHandler(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, `wss:\/\/example.com\/logs\/ws`) {
+		t.Error("expected escaped wss://example.com/logs/ws in body")
+	}
+}
+
+func TestLogSocketViewHandler_ForwardedHTTPOverridesTLS(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/logs/", nil)
+	req.TLS = &tls.ConnectionState{}
+	req.Header.Set("X-Forwarded-Proto", "http")
+	w := httptest.NewRecorder()
+	LogSocketViewHandler(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, `ws:\/\/example.com\/logs\/ws`) {
+		t.Error("expected escaped ws://example.com/logs/ws in body")
 	}
 }


### PR DESCRIPTION
## Summary
- prefer `X-Forwarded-Proto` when building the embedded viewer websocket URL
- keep TLS fallback for direct deployments
- add regression coverage for forwarded http/https cases

## Testing
- go test ./...
- staticcheck ./...
- go test -race ./browser ./ws ./log ./slog