### PR TITLE
build(go): update toolchain directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/taigrr/log-socket/v2
 
-go 1.26.1
+go 1.26.5
 
 require github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
## Summary
- update the Go directive from 1.26.1 to the current 1.26.5 patch release

## Verification
- go generate ./...
- go test -race ./...
- staticcheck ./...